### PR TITLE
Refactor `getShardIDs` to use `ListShards`

### DIFF
--- a/clientlibrary/worker/worker.go
+++ b/clientlibrary/worker/worker.go
@@ -329,7 +329,6 @@ func (w *Worker) eventLoop() {
 func (w *Worker) getShardIDs(nextToken string, shardInfo map[string]bool) error {
 	log := w.kclConfig.Logger
 
-	// Initialize ListShardsInput
 	args := &kinesis.ListShardsInput{}
 
 	// When you have a nextToken, you can't set the streamName
@@ -365,7 +364,7 @@ func (w *Worker) getShardIDs(nextToken string, shardInfo map[string]bool) error 
 	if listShards.NextToken != nil {
 		err := w.getShardIDs(*listShards.NextToken, shardInfo)
 		if err != nil {
-			log.Errorf("Error in getShardID, Error: %+v", err)
+			log.Errorf("Error in ListShards: %s Error: %+v Request: %s", w.streamName, err, args)
 			return err
 		}
 	}

--- a/clientlibrary/worker/worker.go
+++ b/clientlibrary/worker/worker.go
@@ -326,15 +326,15 @@ func (w *Worker) eventLoop() {
 
 // List all shards and store them into shardStatus table
 // If shard has been removed, need to exclude it from cached shard status.
-func (w *Worker) getShardIDs(nextToken *string, shardInfo map[string]bool) error {
+func (w *Worker) getShardIDs(nextToken string, shardInfo map[string]bool) error {
 	log := w.kclConfig.Logger
 
 	// Initialize ListShardsInput
 	args := &kinesis.ListShardsInput{}
 
 	// When you have a nextToken, you can't set the streamName
-	if nextToken != nil {
-		args.NextToken = nextToken
+	if nextToken != "" {
+		args.NextToken = aws.String(nextToken)
 	} else {
 		args.StreamName = aws.String(w.streamName)
 	}
@@ -363,7 +363,7 @@ func (w *Worker) getShardIDs(nextToken *string, shardInfo map[string]bool) error
 	}
 
 	if listShards.NextToken != nil {
-		err := w.getShardIDs(listShards.NextToken, shardInfo)
+		err := w.getShardIDs(*listShards.NextToken, shardInfo)
 		if err != nil {
 			log.Errorf("Error in getShardID, Error: %+v", err)
 			return err
@@ -377,7 +377,7 @@ func (w *Worker) getShardIDs(nextToken *string, shardInfo map[string]bool) error
 func (w *Worker) syncShard() error {
 	log := w.kclConfig.Logger
 	shardInfo := make(map[string]bool)
-	err := w.getShardIDs(nil, shardInfo)
+	err := w.getShardIDs("", shardInfo)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
Refactor `getShardIDs` to use `ListShards` instead of `DescribeStream`.
This to avoid the limitation introduced by `DescribeStream` by only returning 100 shards per call.
`ListShards` returns up to 10,000 shards per call.